### PR TITLE
Feature/generate-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # cloud-builders
+
+This repository contains source code for Docker images that can be later on used as build steps for [Google Cloud Build](https://cloud.google.com/cloud-build/docs/).
+
+## How to use
+
+Google Cloud Build executes a build as a series of build steps. Each build step is run in a Docker container. See the [Cloud Build documentation](https://cloud.google.com/cloud-build/docs/overview) for more details about builds and build steps.
+
+To use one of the Docker images as a build step, you need to download the source code from this repository and build the image.
+
+Build the image with the following command, replacing `image-name` with the name of the image you want to build and `project-id` with the ID of the project where you want to push the image:
+
+```sh
+./build.sh image-name project-id
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+image_name=$1
+project_id=$2
+
+if [ -z "$image_name" ]; then
+    echo -e "\033[31m❌ Missing image-name, usage: ./build.sh <image-name> <project-id>\033[0m"
+    exit 1
+fi
+
+if [ -z "$project_id" ]; then
+    echo -e "\033[31m❌ Missing project-id, usage: ./build.sh <image-name> <project-id>\033[0m"
+    exit 1
+fi
+
+echo -e "\033[32m🚀 Building image $image_name in project $project_id\033[0m"
+
+# Set gcloud CLI to use the project
+gcloud config set project $project_id
+
+# Working directory
+cd $image_name
+
+# Build the Docker image
+gcloud builds submit --config cloudbuild.yaml . --project $project_id
+
+# View the image in Google Container Registry
+gcloud container images list --filter $image_name --project $project_id

--- a/generate-version/Dockerfile
+++ b/generate-version/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:lts-slim
+
+# Install system dependencies for CLI tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    git \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN (type -p wget >/dev/null || (apt update && apt install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && mkdir -p -m 755 /etc/apt/sources.list.d \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
+
+WORKDIR /app
+CMD ["bash"]

--- a/generate-version/README.md
+++ b/generate-version/README.md
@@ -1,0 +1,38 @@
+# generate-version
+
+This build step image prepares the environment to generate a version for a NodeJS project.
+
+## Configuration
+
+After building the image, you need to configure the build step to use it.
+
+The build step uses the `GITHUB_TOKEN` secret to authenticate with GitHub fine-grained token with the following scopes:
+
+- `Metadata: Read-only`
+- `Pull requests: Read and write`
+
+Here is an example of how to configure the build step:
+
+```yaml
+steps:
+  - name: gcr.io/$PROJECT_ID/generate-version
+    id: generate-version
+    entrypoint: bash
+    secretEnv: ['GITHUB_TOKEN']
+    args:
+      - -lc
+      - |
+        echo "$$GITHUB_TOKEN" | gh auth login --hostname github.com --with-token
+        git config --global user.name "$_GITHUB_USER_NAME"
+        git config --global user.email "$_GITHUB_USER_EMAIL"
+        # your step code here
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/GITHUB_TOKEN/versions/latest
+    env: GITHUB_TOKEN
+
+substitutions:
+  _GITHUB_USER_NAME: cloud-build # replace with your GitHub username
+  _GITHUB_USER_EMAIL: cloud-build@$PROJECT_ID.iam.gserviceaccount.com # replace with your GitHub user email
+```

--- a/generate-version/cloudbuild.yaml
+++ b/generate-version/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/generate-version', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/generate-version'
+tags: ['cloud-builders']


### PR DESCRIPTION
This pull request introduces initial documentation and tooling for building and using custom Docker images as build steps with Google Cloud Build, and adds a specific image for NodeJS version generation with GitHub integration. The main changes are the addition of usage instructions, a build script, and the setup for the `generate-version` image.

**General Cloud Build tooling:**

* Added a repository-level `README.md` with instructions on building and using Docker images as Cloud Build steps.
* Introduced a `build.sh` script to automate building and pushing images to Google Cloud projects, including error handling and usage instructions.

**`generate-version` image setup:**

* Added a `generate-version/Dockerfile` that installs NodeJS, system dependencies, and the GitHub CLI for use in build steps.
* Created a `generate-version/README.md` with setup instructions, required GitHub token scopes, and example Cloud Build configuration for authentication and usage.
* Added a `generate-version/cloudbuild.yaml` for building and tagging the `generate-version` image in Cloud Build.